### PR TITLE
Refactor

### DIFF
--- a/library/src/main/java/no/hyper/dateintervalpicker/DateIntervalPicker.java
+++ b/library/src/main/java/no/hyper/dateintervalpicker/DateIntervalPicker.java
@@ -5,10 +5,12 @@ import android.app.Activity;
 import android.app.Fragment;
 import android.content.Context;
 import android.content.pm.ActivityInfo;
+import android.content.res.TypedArray;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
 import android.util.AttributeSet;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -33,6 +35,8 @@ public class DateIntervalPicker extends LinearLayout implements View.OnTouchList
     private int downPos;  //grid position of touch start
     private ArrayList<LinearLayout> selectedItems;
 
+    TypedArray attributes;
+
     public DateIntervalPicker(Context context) {
         this(context, null, 0);
     }
@@ -43,6 +47,7 @@ public class DateIntervalPicker extends LinearLayout implements View.OnTouchList
 
     public DateIntervalPicker(Context context, AttributeSet attrs, int defStyleAttr) {
         super(context, attrs, defStyleAttr);
+        attributes = context.obtainStyledAttributes(attrs, R.styleable.DateIntervalPicker);
         onCreate();
     }
 
@@ -52,12 +57,16 @@ public class DateIntervalPicker extends LinearLayout implements View.OnTouchList
 
         calendar = (GridView) v.findViewById(R.id.calendar_grid);
 
-        adapter = new PickerAdapter(getContext());
+        adapter = new PickerAdapter(getContext(), attributes);
 
         calendar.setAdapter(adapter);
         calendar.setOnTouchListener(this);
         selectedItems = new ArrayList<LinearLayout>();
+
+        int headerFontSize = attributes.getDimensionPixelSize(R.styleable.DateIntervalPicker_headerTextSize, 14);
+
         month = (TextView) v.findViewById(R.id.month);
+        month.setTextSize(TypedValue.COMPLEX_UNIT_SP, headerFontSize);
         month.setText(adapter.getMonthString());
 
         View.OnClickListener ocl = new View.OnClickListener() {
@@ -67,8 +76,13 @@ public class DateIntervalPicker extends LinearLayout implements View.OnTouchList
             }
         };
 
-        v.findViewById(R.id.next_month).setOnClickListener(ocl);
-        v.findViewById(R.id.prev_month).setOnClickListener(ocl);
+        TextView tv = (TextView) v.findViewById(R.id.next_month);
+        tv.setTextSize(TypedValue.COMPLEX_UNIT_SP, headerFontSize);
+        tv.setOnClickListener(ocl);
+
+        tv = (TextView) v.findViewById(R.id.prev_month);
+        tv.setTextSize(TypedValue.COMPLEX_UNIT_SP, headerFontSize);
+        tv.setOnClickListener(ocl);
 
         // the calendar doesn't really work very well in landscape, so lock to portrait mode
         // activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);

--- a/library/src/main/java/no/hyper/dateintervalpicker/DateIntervalPicker.java
+++ b/library/src/main/java/no/hyper/dateintervalpicker/DateIntervalPicker.java
@@ -3,10 +3,12 @@ package no.hyper.dateintervalpicker;
 import android.annotation.TargetApi;
 import android.app.Activity;
 import android.app.Fragment;
+import android.content.Context;
 import android.content.pm.ActivityInfo;
 import android.graphics.Color;
 import android.os.Build;
 import android.os.Bundle;
+import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.MotionEvent;
 import android.view.View;
@@ -20,7 +22,7 @@ import java.util.Calendar;
 import java.util.Date;
 
 
-public class DateIntervalPicker extends Fragment implements View.OnTouchListener{
+public class DateIntervalPicker extends LinearLayout implements View.OnTouchListener{
 
     private GridView calendar;
     private TextView month;
@@ -31,18 +33,26 @@ public class DateIntervalPicker extends Fragment implements View.OnTouchListener
     private int downPos;  //grid position of touch start
     private ArrayList<LinearLayout> selectedItems;
 
-    private Activity activity;  //reference your main activity
+    public DateIntervalPicker(Context context) {
+        this(context, null, 0);
+    }
+
+    public DateIntervalPicker(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public DateIntervalPicker(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+        onCreate();
+    }
 
 
-
-
-    @Override
-    public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-        View v = inflater.inflate(R.layout.date_interval_picker_fragment, container);
+    public View onCreate() {
+        View v = inflate(getContext(), R.layout.date_interval_picker_fragment, this);
 
         calendar = (GridView) v.findViewById(R.id.calendar_grid);
 
-        adapter = new PickerAdapter(activity);
+        adapter = new PickerAdapter(getContext());
 
         calendar.setAdapter(adapter);
         calendar.setOnTouchListener(this);
@@ -60,16 +70,9 @@ public class DateIntervalPicker extends Fragment implements View.OnTouchListener
         v.findViewById(R.id.next_month).setOnClickListener(ocl);
         v.findViewById(R.id.prev_month).setOnClickListener(ocl);
 
-        //the calendar doesn't really work very well in landscape, so lock to portrait mode
-        activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
+        // the calendar doesn't really work very well in landscape, so lock to portrait mode
+        // activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
         return v;
-    }
-
-
-    @Override
-    public void onAttach(Activity activity) {
-        super.onAttach(activity);
-        this.activity = activity;
     }
 
 
@@ -196,7 +199,7 @@ public class DateIntervalPicker extends Fragment implements View.OnTouchListener
     private void clearSelected() {
         for ( LinearLayout ll : selectedItems ) {
             ll.setBackgroundColor(Color.WHITE);
-            ((TextView) ll.findViewById(R.id.date)).setTextColor(activity.getResources().getColor(R.color.gray_dark));
+            ((TextView) ll.findViewById(R.id.date)).setTextColor(getContext().getResources().getColor(R.color.gray_dark));
         }
         selectedItems.clear();
     }

--- a/library/src/main/java/no/hyper/dateintervalpicker/DateIntervalPicker.java
+++ b/library/src/main/java/no/hyper/dateintervalpicker/DateIntervalPicker.java
@@ -89,6 +89,11 @@ public class DateIntervalPicker extends LinearLayout implements View.OnTouchList
         return v;
     }
 
+    public void changeDate(Calendar cal) {
+
+        adapter.setDate(cal);
+        month.setText(adapter.getMonthString());
+    }
 
     public void changeMonth(View v) {
         if (v.getId() == R.id.next_month) {

--- a/library/src/main/java/no/hyper/dateintervalpicker/DateIntervalPicker.java
+++ b/library/src/main/java/no/hyper/dateintervalpicker/DateIntervalPicker.java
@@ -17,6 +17,7 @@ import android.view.View;
 import android.view.ViewGroup;
 import android.widget.GridView;
 import android.widget.LinearLayout;
+import android.widget.RelativeLayout;
 import android.widget.TextView;
 
 import java.util.ArrayList;
@@ -24,7 +25,7 @@ import java.util.Calendar;
 import java.util.Date;
 
 
-public class DateIntervalPicker extends LinearLayout implements View.OnTouchListener{
+public class DateIntervalPicker extends RelativeLayout implements View.OnTouchListener{
 
     private GridView calendar;
     private TextView month;
@@ -52,7 +53,7 @@ public class DateIntervalPicker extends LinearLayout implements View.OnTouchList
     }
 
 
-    public View onCreate() {
+    public void onCreate() {
         View v = inflate(getContext(), R.layout.date_interval_picker_fragment, this);
 
         calendar = (GridView) v.findViewById(R.id.calendar_grid);
@@ -60,7 +61,8 @@ public class DateIntervalPicker extends LinearLayout implements View.OnTouchList
         adapter = new PickerAdapter(getContext(), attributes);
 
         calendar.setAdapter(adapter);
-        calendar.setOnTouchListener(this);
+        if (attributes.getBoolean(R.styleable.DateIntervalPicker_datePickable, false))
+            calendar.setOnTouchListener(this);
         selectedItems = new ArrayList<LinearLayout>();
 
         int headerFontSize = attributes.getDimensionPixelSize(R.styleable.DateIntervalPicker_headerTextSize, 14);
@@ -69,28 +71,29 @@ public class DateIntervalPicker extends LinearLayout implements View.OnTouchList
         month.setTextSize(TypedValue.COMPLEX_UNIT_SP, headerFontSize);
         month.setText(adapter.getMonthString());
 
-        View.OnClickListener ocl = new View.OnClickListener() {
-            @Override
-            public void onClick(View view) {
-                changeMonth(view);
-            }
-        };
+        boolean showPreAndNext = attributes.getBoolean(R.styleable.DateIntervalPicker_showPreAndNext, true);
 
-        TextView tv = (TextView) v.findViewById(R.id.next_month);
-        tv.setTextSize(TypedValue.COMPLEX_UNIT_SP, headerFontSize);
-        tv.setOnClickListener(ocl);
+        if (showPreAndNext) {
+            View.OnClickListener ocl = new View.OnClickListener() {
+                @Override
+                public void onClick(View view) {
+                    changeMonth(view);
+                }
+            };
 
-        tv = (TextView) v.findViewById(R.id.prev_month);
-        tv.setTextSize(TypedValue.COMPLEX_UNIT_SP, headerFontSize);
-        tv.setOnClickListener(ocl);
+            TextView tv = (TextView) v.findViewById(R.id.next_month);
+            tv.setTextSize(TypedValue.COMPLEX_UNIT_SP, headerFontSize);
+            tv.setOnClickListener(ocl);
 
+            tv = (TextView) v.findViewById(R.id.prev_month);
+            tv.setTextSize(TypedValue.COMPLEX_UNIT_SP, headerFontSize);
+            tv.setOnClickListener(ocl);
+        }
         // the calendar doesn't really work very well in landscape, so lock to portrait mode
         // activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
-        return v;
     }
 
     public void changeDate(Calendar cal) {
-
         adapter.setDate(cal);
         month.setText(adapter.getMonthString());
     }

--- a/library/src/main/java/no/hyper/dateintervalpicker/DateIntervalPicker.java
+++ b/library/src/main/java/no/hyper/dateintervalpicker/DateIntervalPicker.java
@@ -34,7 +34,7 @@ public class DateIntervalPicker extends RelativeLayout implements View.OnTouchLi
     private Date fromDate, toDate;
 
     private int downPos;  //grid position of touch start
-    private ArrayList<LinearLayout> selectedItems;
+    private ArrayList<TextView> selectedItems;
 
     TypedArray attributes;
 
@@ -63,7 +63,7 @@ public class DateIntervalPicker extends RelativeLayout implements View.OnTouchLi
         calendar.setAdapter(adapter);
         if (attributes.getBoolean(R.styleable.DateIntervalPicker_datePickable, false))
             calendar.setOnTouchListener(this);
-        selectedItems = new ArrayList<LinearLayout>();
+        selectedItems = new ArrayList<TextView>();
 
         int headerFontSize = attributes.getDimensionPixelSize(R.styleable.DateIntervalPicker_headerTextSize, 14);
 
@@ -169,7 +169,7 @@ public class DateIntervalPicker extends RelativeLayout implements View.OnTouchLi
 
 
     private void selectItem(int position) {
-        LinearLayout ll = (LinearLayout) calendar.getItemAtPosition(position);
+        TextView ll = (TextView) calendar.getItemAtPosition(position);
         if ( ll != null && ll.isEnabled()) {
             selectedItems.add(ll);
         }
@@ -221,7 +221,7 @@ public class DateIntervalPicker extends RelativeLayout implements View.OnTouchLi
     }
 
     private void clearSelected() {
-        for ( LinearLayout ll : selectedItems ) {
+        for ( TextView ll : selectedItems ) {
             ll.setBackgroundColor(Color.TRANSPARENT);
             ((TextView) ll.findViewById(R.id.date)).setTextColor(getContext().getResources().getColor(R.color.gray_dark));
         }

--- a/library/src/main/java/no/hyper/dateintervalpicker/DateIntervalPicker.java
+++ b/library/src/main/java/no/hyper/dateintervalpicker/DateIntervalPicker.java
@@ -84,10 +84,12 @@ public class DateIntervalPicker extends RelativeLayout implements View.OnTouchLi
             TextView tv = (TextView) v.findViewById(R.id.next_month);
             tv.setTextSize(TypedValue.COMPLEX_UNIT_SP, headerFontSize);
             tv.setOnClickListener(ocl);
+            tv.setVisibility(View.VISIBLE);
 
             tv = (TextView) v.findViewById(R.id.prev_month);
             tv.setTextSize(TypedValue.COMPLEX_UNIT_SP, headerFontSize);
             tv.setOnClickListener(ocl);
+            tv.setVisibility(View.VISIBLE);
         }
         // the calendar doesn't really work very well in landscape, so lock to portrait mode
         // activity.setRequestedOrientation(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
@@ -220,7 +222,7 @@ public class DateIntervalPicker extends RelativeLayout implements View.OnTouchLi
 
     private void clearSelected() {
         for ( LinearLayout ll : selectedItems ) {
-            ll.setBackgroundColor(Color.WHITE);
+            ll.setBackgroundColor(Color.TRANSPARENT);
             ((TextView) ll.findViewById(R.id.date)).setTextColor(getContext().getResources().getColor(R.color.gray_dark));
         }
         selectedItems.clear();

--- a/library/src/main/java/no/hyper/dateintervalpicker/PickerAdapter.java
+++ b/library/src/main/java/no/hyper/dateintervalpicker/PickerAdapter.java
@@ -27,7 +27,9 @@ public class PickerAdapter extends BaseAdapter {
     private Locale locale = Locale.getDefault();
     private ArrayList<String> days;
     private ArrayList<String> dates;
-    private HashMap<Integer, LinearLayout> containers;
+
+    // TODO: Not a very good practise to holding to the view layer components
+    private HashMap<Integer, TextView> containers;
     private int visibleMonth;
     private int visibleYear;
     private Context context;
@@ -54,7 +56,7 @@ public class PickerAdapter extends BaseAdapter {
             }
         }
         dates = new ArrayList<String>();
-        containers = new HashMap<Integer, LinearLayout>();
+        containers = new HashMap<Integer, TextView>();
         buildArray(calendar.get(Calendar.MONTH), calendar.get(Calendar.YEAR));
 
     }
@@ -74,7 +76,7 @@ public class PickerAdapter extends BaseAdapter {
     }
 
     @Override
-    public LinearLayout getItem(int i) {
+    public TextView getItem(int i) {
         return containers.get(i);
     }
 
@@ -91,7 +93,7 @@ public class PickerAdapter extends BaseAdapter {
             convertView = LayoutInflater.from(context)
                     .inflate(R.layout.date_item, parent, false);
 
-            dateView = (TextView) convertView.findViewById(R.id.date);
+            dateView = (TextView) convertView;
             dateView.setTextSize(TypedValue.COMPLEX_UNIT_SP, dateTextSize);
             convertView.setTag(new ViewHolder(dateView));
         } else {
@@ -108,9 +110,9 @@ public class PickerAdapter extends BaseAdapter {
         else {
             dateView.setTextColor(context.getResources().getColor(R.color.gray_dark));
             convertView.setEnabled(true);
-
         }
-        containers.put(position, (LinearLayout) convertView);
+
+        containers.put(position, dateView);
         return convertView;
     }
 
@@ -125,9 +127,9 @@ public class PickerAdapter extends BaseAdapter {
         dates.clear();
         startPosition = 7; //minumum starting position is Monday after day row.
 
-        for (LinearLayout ll : containers.values()) {
-            ll.setBackgroundColor(Color.TRANSPARENT);
-        }
+//        for (LinearLayout ll : containers.values()) {
+//            ll.setBackgroundColor(Color.TRANSPARENT);
+//        }
 
         //add day names for first row
         for (String day : days) {

--- a/library/src/main/java/no/hyper/dateintervalpicker/PickerAdapter.java
+++ b/library/src/main/java/no/hyper/dateintervalpicker/PickerAdapter.java
@@ -151,6 +151,11 @@ public class PickerAdapter extends BaseAdapter {
         }
     }
 
+    public void setDate(Calendar calendar) {
+        buildArray(calendar.get(Calendar.MONTH), calendar.get(Calendar.YEAR));
+        notifyDataSetChanged();
+    }
+
     public void nextMonth() {
         if (calendar.get(Calendar.MONTH) == Calendar.DECEMBER) {
             buildArray(Calendar.JANUARY, calendar.get(Calendar.YEAR) + 1);

--- a/library/src/main/java/no/hyper/dateintervalpicker/PickerAdapter.java
+++ b/library/src/main/java/no/hyper/dateintervalpicker/PickerAdapter.java
@@ -126,7 +126,7 @@ public class PickerAdapter extends BaseAdapter {
         startPosition = 7; //minumum starting position is Monday after day row.
 
         for (LinearLayout ll : containers.values()) {
-            ll.setBackgroundColor(Color.WHITE);
+            ll.setBackgroundColor(Color.TRANSPARENT);
         }
 
         //add day names for first row

--- a/library/src/main/java/no/hyper/dateintervalpicker/PickerAdapter.java
+++ b/library/src/main/java/no/hyper/dateintervalpicker/PickerAdapter.java
@@ -1,7 +1,9 @@
 package no.hyper.dateintervalpicker;
 
 import android.content.Context;
+import android.content.res.TypedArray;
 import android.graphics.Color;
+import android.util.TypedValue;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -31,11 +33,15 @@ public class PickerAdapter extends BaseAdapter {
     private Context context;
     private int startPosition;
 
-    public PickerAdapter(Context context) {
+    private int dateTextSize;
+
+    public PickerAdapter(Context context, TypedArray attributes) {
         this.context = context;
         calendar = Calendar.getInstance(Locale.getDefault());
         calendar.setTime(new Date());
         locale = Locale.getDefault();
+
+        dateTextSize = attributes.getDimensionPixelSize(R.styleable.DateIntervalPicker_dateTextSize, 14);
 
         //first set day initials for use in top row
         days = new ArrayList<String>();
@@ -86,6 +92,7 @@ public class PickerAdapter extends BaseAdapter {
                     .inflate(R.layout.date_item, parent, false);
 
             dateView = (TextView) convertView.findViewById(R.id.date);
+            dateView.setTextSize(TypedValue.COMPLEX_UNIT_SP, dateTextSize);
             convertView.setTag(new ViewHolder(dateView));
         } else {
             ViewHolder viewHolder = (ViewHolder) convertView.getTag();

--- a/library/src/main/java/no/hyper/dateintervalpicker/YearPicker.java
+++ b/library/src/main/java/no/hyper/dateintervalpicker/YearPicker.java
@@ -1,0 +1,65 @@
+package no.hyper.dateintervalpicker;
+
+import android.content.Context;
+import android.util.AttributeSet;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ArrayAdapter;
+import android.widget.GridView;
+import android.widget.SimpleAdapter;
+
+import java.util.Calendar;
+import java.util.Date;
+
+/**
+ * Created by Administrator on 2015/4/1.
+ */
+public class YearPicker extends GridView {
+    public YearPicker(Context context) {
+        this(context, null, 0);
+    }
+
+    public YearPicker(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public YearPicker(Context context, AttributeSet attrs, int defStyle) {
+        super(context, attrs, defStyle);
+        onCreate();
+    }
+
+    public void onCreate() {
+        setAdapter(new MonthAdapter(getContext(), Calendar.getInstance()));
+    }
+
+
+    private static class MonthAdapter extends ArrayAdapter<Date> {
+        private Calendar yearToDisplay;
+        public MonthAdapter(Context context, Calendar calendar) {
+            super(context, 0, new Date[12]);
+            yearToDisplay = calendar;
+        }
+
+        public void setYearToDisplay(Calendar c) {
+            this.yearToDisplay = c;
+        }
+
+        @Override
+        public View getView(int position, View convertView, ViewGroup parent) {
+            if (convertView == null) {
+                convertView = LayoutInflater.from(getContext()).inflate(R.layout.month_item_view, parent, false);
+            }
+
+            DateIntervalPicker view = (DateIntervalPicker)convertView;
+
+            int tmp = yearToDisplay.get(Calendar.MONTH);
+            yearToDisplay.set(Calendar.MONTH, position);
+            view.changeDate(yearToDisplay);
+            yearToDisplay.set(Calendar.MONTH, tmp);
+            convertView = view;
+
+            return convertView;
+        }
+    }
+}

--- a/library/src/main/res/layout/date_interval_picker_fragment.xml
+++ b/library/src/main/res/layout/date_interval_picker_fragment.xml
@@ -1,10 +1,4 @@
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    android:layout_width="match_parent"
-    android:layout_height="match_parent"
-    android:orientation="vertical"
-    tools:context=".DateIntervalPicker"
-    android:background="@android:color/white">
+<merge xmlns:android="http://schemas.android.com/apk/res/android">
     <LinearLayout
         android:id="@+id/linearLayout"
         android:layout_width="match_parent"
@@ -67,4 +61,4 @@
 
     </GridView>
 
-</RelativeLayout>
+</merge>

--- a/library/src/main/res/layout/date_interval_picker_fragment.xml
+++ b/library/src/main/res/layout/date_interval_picker_fragment.xml
@@ -1,57 +1,63 @@
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical"
     tools:context=".DateIntervalPicker"
     android:background="@android:color/white">
-
     <LinearLayout
+        android:id="@+id/linearLayout"
         android:layout_width="match_parent"
-        android:layout_height="60dp"
-        android:background="@color/gray_light"
-        android:gravity="center_vertical"
-        android:orientation="horizontal"
-        android:paddingLeft="@dimen/activity_horizontal_margin"
-        android:paddingRight="@dimen/activity_horizontal_margin"
-        >
-
-
-        <ImageView
+        android:layout_height="wrap_content"
+        android:layout_alignParentTop="true"
+        android:gravity="center"
+        android:orientation="horizontal">
+        <TextView
             android:id="@+id/prev_month"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/ic_calendar_prev"
+            android:text="&lt;"
+            android:paddingLeft="@dimen/activity_horizontal_margin"
+            android:paddingRight="@dimen/activity_horizontal_margin"
+            android:textSize="18sp"
             />
 
         <TextView
-            android:layout_width="0dp"
-            android:layout_weight="0.8"
+            android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:textSize="22sp"
-            android:gravity="center"
+            android:gravity="center_horizontal"
+            android:layout_weight="0.8"
+            android:textSize="18sp"
             android:id="@+id/month"
             android:textAllCaps="true"
             android:textColor="@color/gray_dark"/>
 
-        <ImageView
+        <TextView
+            android:id="@+id/next_month"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:src="@drawable/ic_calendar_next"
-            android:id="@+id/next_month"
-        />
-    </LinearLayout>
+            android:paddingRight="@dimen/activity_horizontal_margin"
+            android:paddingLeft="@dimen/activity_horizontal_margin"
+            android:text="&gt;"
+            android:textSize="18sp"
+            />
+        </LinearLayout>
 
+
+    <View
+        android:id="@+id/divider"
+        android:layout_below="@id/linearLayout"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:background="@color/gray_dark"/>
     <GridView
         android:id="@+id/calendar_grid"
+        android:layout_below="@id/divider"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:numColumns="7"
         android:stretchMode="columnWidth"
         android:gravity="center"
-        android:paddingLeft="@dimen/activity_horizontal_margin"
-        android:paddingRight="@dimen/activity_horizontal_margin"
-        android:paddingBottom="@dimen/activity_horizontal_margin"
         android:layout_gravity="center_horizontal"
         android:background="@drawable/bottom_border"
         android:verticalSpacing="2dp"
@@ -59,4 +65,4 @@
 
     </GridView>
 
-</LinearLayout>
+</RelativeLayout>

--- a/library/src/main/res/layout/date_interval_picker_fragment.xml
+++ b/library/src/main/res/layout/date_interval_picker_fragment.xml
@@ -20,6 +20,7 @@
             android:paddingLeft="@dimen/activity_horizontal_margin"
             android:paddingRight="@dimen/activity_horizontal_margin"
             android:textSize="18sp"
+            android:visibility="gone"
             />
 
         <TextView
@@ -40,6 +41,7 @@
             android:paddingLeft="@dimen/activity_horizontal_margin"
             android:text="&gt;"
             android:textSize="18sp"
+            android:visibility="gone"
             />
         </LinearLayout>
 
@@ -59,9 +61,9 @@
         android:stretchMode="columnWidth"
         android:gravity="center"
         android:layout_gravity="center_horizontal"
-        android:background="@drawable/bottom_border"
         android:verticalSpacing="2dp"
     >
+        <!--android:background="@drawable/bottom_border"-->
 
     </GridView>
 

--- a/library/src/main/res/layout/date_interval_picker_fragment.xml
+++ b/library/src/main/res/layout/date_interval_picker_fragment.xml
@@ -12,23 +12,17 @@
         android:background="@color/gray_light"
         android:gravity="center_vertical"
         android:orientation="horizontal"
+        android:paddingLeft="@dimen/activity_horizontal_margin"
+        android:paddingRight="@dimen/activity_horizontal_margin"
         >
 
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="0.1"
-            android:paddingLeft="@dimen/activity_horizontal_margin"
-            android:gravity="center"
-            android:id="@+id/prev_month"
-            >
 
-            <ImageView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/ic_calendar_prev"
-                />
-        </LinearLayout>
+        <ImageView
+            android:id="@+id/prev_month"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_calendar_prev"
+            />
 
         <TextView
             android:layout_width="0dp"
@@ -40,22 +34,12 @@
             android:textAllCaps="true"
             android:textColor="@color/gray_dark"/>
 
-
-        <LinearLayout
-            android:layout_width="0dp"
-            android:layout_height="match_parent"
-            android:layout_weight="0.1"
-            android:paddingRight="@dimen/activity_horizontal_margin"
-            android:gravity="center"
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/ic_calendar_next"
             android:id="@+id/next_month"
-            >
-
-            <ImageView
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:src="@drawable/ic_calendar_next"
-            />
-        </LinearLayout>
+        />
     </LinearLayout>
 
     <GridView

--- a/library/src/main/res/layout/date_item.xml
+++ b/library/src/main/res/layout/date_item.xml
@@ -4,19 +4,17 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center"
     android:id="@+id/date_container"
     >
 
     <TextView
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
+        xmlns:android="http://schemas.android.com/apk/res/android"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:gravity="center_horizontal"
         android:text="12"
         android:id="@+id/date"
         android:textAllCaps="true"
-        android:textSize="16sp"
-        android:paddingTop="8dp"
-        android:paddingBottom="8dp"
         android:textColor="@color/gray_dark"
    />
 

--- a/library/src/main/res/layout/date_item.xml
+++ b/library/src/main/res/layout/date_item.xml
@@ -1,21 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:orientation="vertical"
+<TextView
+    xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:id="@+id/date_container"
-    >
-
-    <TextView
-        xmlns:android="http://schemas.android.com/apk/res/android"
-        android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center_horizontal"
-        android:text="12"
-        android:id="@+id/date"
-        android:textAllCaps="true"
-        android:textColor="@color/gray_dark"
-   />
-
-</LinearLayout>
+    android:gravity="center_horizontal"
+    android:text="12"
+    android:id="@+id/date"
+    android:textAllCaps="true"
+    android:textColor="@color/gray_dark"
+/>

--- a/library/src/main/res/layout/month_item_view.xml
+++ b/library/src/main/res/layout/month_item_view.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<no.hyper.dateintervalpicker.DateIntervalPicker
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    app:dateTextSize="6sp"
+    app:headerTextSize="6sp"
+    app:showPreAndNext="false"
+    app:datePickable="false"
+    android:layout_width="wrap_content"
+    android:layout_gravity="center"
+    android:layout_height="150dp"
+    android:id="@+id/picker_fragment"/>
+    <!--android:layout_height="wrap_content"-->

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -3,6 +3,7 @@
         <attr name="dateTextSize" format="dimension"/>
         <attr name="headerTextSize" format="dimension"/>
         <attr name="showPreAndNext" format="boolean"/>
+        <attr name="datePickable" format="boolean"/>
         <attr name="headerPadding" format="dimension"/>
         <attr name="bodyPadding" format="dimension"/>
     </declare-styleable>

--- a/library/src/main/res/values/attrs.xml
+++ b/library/src/main/res/values/attrs.xml
@@ -1,0 +1,9 @@
+<resources>
+    <declare-styleable name="DateIntervalPicker">
+        <attr name="dateTextSize" format="dimension"/>
+        <attr name="headerTextSize" format="dimension"/>
+        <attr name="showPreAndNext" format="boolean"/>
+        <attr name="headerPadding" format="dimension"/>
+        <attr name="bodyPadding" format="dimension"/>
+    </declare-styleable>
+</resources>

--- a/sample/src/main/AndroidManifest.xml
+++ b/sample/src/main/AndroidManifest.xml
@@ -8,8 +8,17 @@
         android:label="@string/app_name"
         android:theme="@style/AppTheme" >
         <activity
-            android:name="no.hyper.dateintervalpicker.sample.MainActivity"
+            android:name=".MainActivity"
             android:label="@string/app_name" >
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+        <activity
+            android:name=".MainActivity2"
+            android:label="@string/title_activity_main_activity2" >
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 

--- a/sample/src/main/java/no/hyper/dateintervalpicker/sample/MainActivity.java
+++ b/sample/src/main/java/no/hyper/dateintervalpicker/sample/MainActivity.java
@@ -7,6 +7,8 @@ import android.view.MenuItem;
 import android.view.View;
 import android.widget.Toast;
 
+import java.util.Calendar;
+
 import no.hyper.dateintervalpicker.DateIntervalPicker;
 
 /**
@@ -24,6 +26,9 @@ public class MainActivity extends ActionBarActivity {
         setContentView(R.layout.main_activity);
 
         picker = (DateIntervalPicker) findViewById(R.id.picker_fragment);
+        Calendar cal = Calendar.getInstance();
+        cal.add(Calendar.MONTH, -12);
+        picker.changeDate(cal);
 
     }
 

--- a/sample/src/main/java/no/hyper/dateintervalpicker/sample/MainActivity.java
+++ b/sample/src/main/java/no/hyper/dateintervalpicker/sample/MainActivity.java
@@ -37,7 +37,7 @@ public class MainActivity extends ActionBarActivity {
      * @param v
      */
     public void confirm(View v) {
-        Toast.makeText(this, picker.getFromDate() + " to " + picker.getToDate() + " selected", Toast.LENGTH_LONG).show();
+        Toast.makeText(this, picker.getFromDate() + " to " + picker.getToDate() + " selected", Toast.LENGTH_SHORT).show();
     }
 
 }

--- a/sample/src/main/java/no/hyper/dateintervalpicker/sample/MainActivity.java
+++ b/sample/src/main/java/no/hyper/dateintervalpicker/sample/MainActivity.java
@@ -23,7 +23,7 @@ public class MainActivity extends ActionBarActivity {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.main_activity);
 
-        picker = (DateIntervalPicker) getFragmentManager().findFragmentById(R.id.picker_fragment);
+        picker = (DateIntervalPicker) findViewById(R.id.picker_fragment);
 
     }
 

--- a/sample/src/main/java/no/hyper/dateintervalpicker/sample/MainActivity2.java
+++ b/sample/src/main/java/no/hyper/dateintervalpicker/sample/MainActivity2.java
@@ -1,0 +1,39 @@
+package no.hyper.dateintervalpicker.sample;
+
+import android.support.v7.app.ActionBarActivity;
+import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuItem;
+
+
+public class MainActivity2 extends ActionBarActivity {
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.main_activity2);
+    }
+
+
+    @Override
+    public boolean onCreateOptionsMenu(Menu menu) {
+        // Inflate the menu; this adds items to the action bar if it is present.
+        getMenuInflater().inflate(R.menu.menu_main_activity2, menu);
+        return true;
+    }
+
+    @Override
+    public boolean onOptionsItemSelected(MenuItem item) {
+        // Handle action bar item clicks here. The action bar will
+        // automatically handle clicks on the Home/Up button, so long
+        // as you specify a parent activity in AndroidManifest.xml.
+        int id = item.getItemId();
+
+        //noinspection SimplifiableIfStatement
+        if (id == R.id.action_settings) {
+            return true;
+        }
+
+        return super.onOptionsItemSelected(item);
+    }
+}

--- a/sample/src/main/res/layout/main_activity.xml
+++ b/sample/src/main/res/layout/main_activity.xml
@@ -6,14 +6,14 @@
     android:layout_height="match_parent">
 
     <no.hyper.dateintervalpicker.DateIntervalPicker
-        app:dateTextSize="6sp"
-        app:headerTextSize="6sp"
-        android:layout_width="120dp"
+        app:dateTextSize="14sp"
+        app:headerTextSize="14sp"
+        app:datePickable="true"
+        app:showPreAndNext="true"
+        android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:name="no.hyper.dateintervalpicker.DateIntervalPicker"
-        android:id="@+id/picker_fragment">
-
-    </no.hyper.dateintervalpicker.DateIntervalPicker>
+        android:id="@+id/picker_fragment"/>
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/sample/src/main/res/layout/main_activity.xml
+++ b/sample/src/main/res/layout/main_activity.xml
@@ -4,13 +4,13 @@
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent">
 
-    <fragment
+    <no.hyper.dateintervalpicker.DateIntervalPicker
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:name="no.hyper.dateintervalpicker.DateIntervalPicker"
         android:id="@+id/picker_fragment">
 
-    </fragment>
+    </no.hyper.dateintervalpicker.DateIntervalPicker>
 
     <LinearLayout
         android:layout_width="match_parent"

--- a/sample/src/main/res/layout/main_activity.xml
+++ b/sample/src/main/res/layout/main_activity.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:orientation="vertical" android:layout_width="match_parent"
     android:layout_height="match_parent">
 
     <no.hyper.dateintervalpicker.DateIntervalPicker
-        android:layout_width="match_parent"
+        app:dateTextSize="6sp"
+        app:headerTextSize="6sp"
+        android:layout_width="120dp"
         android:layout_height="wrap_content"
         android:name="no.hyper.dateintervalpicker.DateIntervalPicker"
         android:id="@+id/picker_fragment">

--- a/sample/src/main/res/layout/main_activity2.xml
+++ b/sample/src/main/res/layout/main_activity2.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical" android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <no.hyper.dateintervalpicker.YearPicker
+        android:padding="4dp"
+        android:horizontalSpacing="4dp"
+        android:verticalSpacing="4dp"
+        android:layout_width="match_parent"
+        android:numColumns="3"
+        android:layout_height="wrap_content"/>
+
+</LinearLayout>

--- a/sample/src/main/res/menu/menu_main_activity2.xml
+++ b/sample/src/main/res/menu/menu_main_activity2.xml
@@ -1,0 +1,7 @@
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    tools:context="no.hyper.dateintervalpicker.sample.MainActivity2">
+    <item android:id="@+id/action_settings" android:title="@string/action_settings"
+        android:orderInCategory="100" app:showAsAction="never" />
+</menu>

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -6,4 +6,5 @@
     <string name="action_settings">Settings</string>
 
     <string name="select_dates">Confirm</string>
+    <string name="title_activity_main_activity2">MainActivity2</string>
 </resources>


### PR DESCRIPTION
1. Use View a reusable component, not Fragment
2. Simplify the [grid item] layout - a TextView could suffice. We don't need a Layout View outside the TextView
3. use <merge> tag for root element in date_interval_picker_fragment.xml
4. add a few more configurable attributes - so that users can specify those values in Layout Files.
#5. Add a view to display 12 months of a year

TODO:
#1. Enhance one year calendar

Known issues:
1. AdapterView::getItem() are supposed to return a POJO/VO/MODEL object. Not a whole VIEW. Take the case of a ListView of 100 elements. To save memory, there could be only 10 View elements (suppose 10 elements would accommodate a whole page). When scrolling down, the Views are not going to be re-created, they are going to be reuse
